### PR TITLE
Feature/Form utils

### DIFF
--- a/libs/ngx-nuts-and-bolts/form-utils/README.md
+++ b/libs/ngx-nuts-and-bolts/form-utils/README.md
@@ -1,0 +1,27 @@
+# @infinum/ngx-nuts-and-bolts/form-utils
+
+Secondary entry point of `@infinum/ngx-nuts-and-bolts`. It can be used by importing from `@infinum/ngx-nuts-and-bolts/form-utils`.
+
+## 1. Features
+
+Currently, the types for a form value or raw form value are not publicly exposed. The helper types FormValue and RawFormValue enable you to retrieve a value or a raw value typings from an Angular form.
+
+## 2. Usage
+
+To leverage these type helpers, you must first create a helper function that returns an Angular FormGroup, FormControl, etc.
+
+```ts
+export function createExampleForm() {
+	return new FormGroup({
+		exampleControlOne: new FormControl('', { nonNullable: true }),
+		exampleControlTwo: new FormControl(''),
+	});
+}
+```
+
+Now, pass the function's return type using the TypeScript ReturnType utility type to the form type helper as a generic argument and create new form value and raw form value types as needed for this specific form.
+
+```ts
+export type ExampleFormValue = FormValue<ReturnType<typeof createExampleForm>>;
+export type ExampleRawFormValue = RawFormValue<ReturnType<typeof createExampleForm>>;
+```

--- a/libs/ngx-nuts-and-bolts/form-utils/README.md
+++ b/libs/ngx-nuts-and-bolts/form-utils/README.md
@@ -4,11 +4,11 @@ Secondary entry point of `@infinum/ngx-nuts-and-bolts`. It can be used by import
 
 ## 1. Features
 
-Currently, the types for a form value or raw form value are not publicly exposed. The helper types FormValue and RawFormValue enable you to retrieve a value or a raw value typings from an Angular form.
+Currently, the types for a form value or raw form value are not publicly exposed. The helper types `FormValue` and `RawFormValue` enable you to retrieve a value or a raw value typings from an Angular form.
 
 ## 2. Usage
 
-To leverage these type helpers, you must first create a helper function that returns an Angular FormGroup, FormControl, etc.
+To leverage these type helpers, you must first create a helper function that returns an Angular `FormGroup`, `FormControl`, etc.
 
 ```ts
 export function createExampleForm() {
@@ -19,7 +19,7 @@ export function createExampleForm() {
 }
 ```
 
-Now, pass the function's return type using the TypeScript ReturnType utility type to the form type helper as a generic argument and create new form value and raw form value types as needed for this specific form.
+Now, pass the function's return type using the TypeScript `ReturnType` utility type to the form type helper as a generic argument and create new form value and raw form value types as needed for this specific form.
 
 ```ts
 export type ExampleFormValue = FormValue<ReturnType<typeof createExampleForm>>;

--- a/libs/ngx-nuts-and-bolts/form-utils/README.md
+++ b/libs/ngx-nuts-and-bolts/form-utils/README.md
@@ -4,7 +4,7 @@ Secondary entry point of `@infinum/ngx-nuts-and-bolts`. It can be used by import
 
 ## 1. Features
 
-Currently, the types for a form value or raw form value are not publicly exposed. The helper types `FormValue` and `RawFormValue` enable you to retrieve a value or a raw value typings from an Angular form.
+Currently, the types for a form value or raw form value [are not publicly exposed from Angular](https://github.com/angular/angular/blob/c4de4e1f894001d8f80b70297c5e576f2d11ec6f/packages/forms/src/model/abstract_model.ts#L227). The helper types `FormValue` and `RawFormValue` enable you to retrieve a value or a raw value typings from an Angular form.
 
 ## 2. Usage
 

--- a/libs/ngx-nuts-and-bolts/form-utils/ng-package.json
+++ b/libs/ngx-nuts-and-bolts/form-utils/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngx-nuts-and-bolts/form-utils/src/index.ts
+++ b/libs/ngx-nuts-and-bolts/form-utils/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types/form-value.type';
+export * from './types/raw-form-value.type';

--- a/libs/ngx-nuts-and-bolts/form-utils/src/types/form-value.type.ts
+++ b/libs/ngx-nuts-and-bolts/form-utils/src/types/form-value.type.ts
@@ -1,0 +1,3 @@
+import { AbstractControl } from '@angular/forms';
+
+export type FormValue<T extends AbstractControl> = T['value'];

--- a/libs/ngx-nuts-and-bolts/form-utils/src/types/raw-form-value.type.ts
+++ b/libs/ngx-nuts-and-bolts/form-utils/src/types/raw-form-value.type.ts
@@ -1,0 +1,3 @@
+import { AbstractControl } from '@angular/forms';
+
+export type RawFormValue<T extends AbstractControl> = ReturnType<T['getRawValue']>;

--- a/libs/ngx-nuts-and-bolts/project.json
+++ b/libs/ngx-nuts-and-bolts/project.json
@@ -56,7 +56,9 @@
 					"libs/ngx-nuts-and-bolts/loading-state/**/*.ts",
 					"libs/ngx-nuts-and-bolts/loading-state/**/*.html",
 					"libs/ngx-nuts-and-bolts/table-state/**/*.ts",
-					"libs/ngx-nuts-and-bolts/table-state/**/*.html"
+					"libs/ngx-nuts-and-bolts/table-state/**/*.html",
+					"libs/ngx-nuts-and-bolts/form-utils/**/*.ts",
+					"libs/ngx-nuts-and-bolts/form-utils/**/*.html"
 				]
 			}
 		},

--- a/ngx-nuts-and-bolts-docs/docs/form-utils.md
+++ b/ngx-nuts-and-bolts-docs/docs/form-utils.md
@@ -1,0 +1,29 @@
+---
+id: form-utils
+title: Form utils
+sidebar_label: Form utils
+---
+
+## 1. Features
+
+Currently, the types for a form value or raw form value are not publicly exposed. The helper types FormValue and RawFormValue enable you to retrieve a value or a raw value typings from an Angular form.
+
+## 2. Usage
+
+To leverage these type helpers, you must first create a helper function that returns an Angular FormGroup, FormControl, etc.
+
+```ts
+export function createExampleForm() {
+	return new FormGroup({
+		exampleControlOne: new FormControl('', { nonNullable: true }),
+		exampleControlTwo: new FormControl(''),
+	});
+}
+```
+
+Now, pass the function's return type using the TypeScript ReturnType utility type to the form type helper as a generic argument and create new form value and raw form value types as needed for this specific form.
+
+```ts
+export type ExampleFormValue = FormValue<ReturnType<typeof createExampleForm>>;
+export type ExampleRawFormValue = RawFormValue<ReturnType<typeof createExampleForm>>;
+```

--- a/ngx-nuts-and-bolts-docs/docs/form-utils.md
+++ b/ngx-nuts-and-bolts-docs/docs/form-utils.md
@@ -6,11 +6,11 @@ sidebar_label: Form utils
 
 ## 1. Features
 
-Currently, the types for a form value or raw form value are not publicly exposed. The helper types FormValue and RawFormValue enable you to retrieve a value or a raw value typings from an Angular form.
+Currently, the types for a form value or raw form value are not publicly exposed. The helper types `FormValue` and `RawFormValue` enable you to retrieve a value or a raw value typings from an Angular form.
 
 ## 2. Usage
 
-To leverage these type helpers, you must first create a helper function that returns an Angular FormGroup, FormControl, etc.
+To leverage these type helpers, you must first create a helper function that returns an Angular `FormGroup`, `FormControl`, etc.
 
 ```ts
 export function createExampleForm() {
@@ -21,7 +21,7 @@ export function createExampleForm() {
 }
 ```
 
-Now, pass the function's return type using the TypeScript ReturnType utility type to the form type helper as a generic argument and create new form value and raw form value types as needed for this specific form.
+Now, pass the function's return type using the TypeScript `ReturnType` utility type to the form type helper as a generic argument and create new form value and raw form value types as needed for this specific form.
 
 ```ts
 export type ExampleFormValue = FormValue<ReturnType<typeof createExampleForm>>;

--- a/ngx-nuts-and-bolts-docs/sidebars.js
+++ b/ngx-nuts-and-bolts-docs/sidebars.js
@@ -45,6 +45,10 @@ const sidebars = {
 			id: 'animations',
 		},
 		{
+			type: 'doc',
+			id: 'form-utils',
+		},
+		{
 			type: 'category',
 			label: 'Testing utilities',
 			items: ['testing-utils/extract-public', 'testing-utils/async-data', 'testing-utils/async-error'],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,6 +20,7 @@
 			"@infinum/ngx-nuts-and-bolts/animations": ["libs/ngx-nuts-and-bolts/animations/src/index.ts"],
 			"@infinum/ngx-nuts-and-bolts/enum-property": ["libs/ngx-nuts-and-bolts/enum-property/src/index.ts"],
 			"@infinum/ngx-nuts-and-bolts/env": ["libs/ngx-nuts-and-bolts/env/src/index.ts"],
+			"@infinum/ngx-nuts-and-bolts/form-utils": ["libs/ngx-nuts-and-bolts/form-utils/src/index.ts"],
 			"@infinum/ngx-nuts-and-bolts/in-view": ["libs/ngx-nuts-and-bolts/in-view/src/index.ts"],
 			"@infinum/ngx-nuts-and-bolts/loading-state": ["libs/ngx-nuts-and-bolts/loading-state/src/index.ts"],
 			"@infinum/ngx-nuts-and-bolts/table-state": ["libs/ngx-nuts-and-bolts/table-state/src/index.ts"],


### PR DESCRIPTION
# Description

This PR adds `FormValue` and `RawFormValue` type helpers which enable you to retrieve a value or a raw value typings from an Angular form.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
