### PR TITLE
feat: add function for getting enum property values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp
 
 # dependencies
 node_modules
+.nx
 
 # IDEs and editors
 /.idea

--- a/apps/environment-variables-fetch-example/src/index.html
+++ b/apps/environment-variables-fetch-example/src/index.html
@@ -8,6 +8,6 @@
 		<link rel="icon" type="image/x-icon" href="favicon.ico" />
 	</head>
 	<body>
-		<ngx-root></ngx-root>
+		<inf-root></inf-root>
 	</body>
 </html>

--- a/libs/ngx-nuts-and-bolts/enum-property/README.md
+++ b/libs/ngx-nuts-and-bolts/enum-property/README.md
@@ -67,3 +67,25 @@ export class ExampleComponent {
 ```
 
 Here, since `directionsData` doesn't have `differentKey` property for any of the enum values, `undefined` would be returned.
+
+If the need for fetching translation keys in the .ts files arises `getTranslationKey()` function is at your disposal, result of which you can pass into transloco service to get the actual translated value for passed in translation key. With this approach we are avoiding need for instantiating `EnumPropertyPipe` class and accessing the `transform` method.
+
+```ts
+import { getTranslationKey } from '@infinum/ngx-nuts-and-bolts';
+
+@Component({
+	selector: 'app-example',
+	template: ``,
+})
+export class ExampleComponent {
+	public enumValue = Directions.NORTH;
+	public directionsData = directionsData;
+
+	private readonly transloco = inject(TranslocoService);
+
+	private translationDemoMethod(): void {
+		const translationKey = getTranslationKey(Directions.NORTH, directionsData);
+		const translation = this.transloco.translate(translationKey as string);
+	}
+}
+```

--- a/libs/ngx-nuts-and-bolts/enum-property/README.md
+++ b/libs/ngx-nuts-and-bolts/enum-property/README.md
@@ -68,10 +68,10 @@ export class ExampleComponent {
 
 Here, since `directionsData` doesn't have `differentKey` property for any of the enum values, `undefined` would be returned.
 
-If the need for fetching translation keys in the .ts files arises `getTranslationKey()` function is at your disposal, result of which you can pass into transloco service to get the actual translated value for passed in translation key. With this approach we are avoiding need for instantiating `EnumPropertyPipe` class and accessing the `transform` method.
+If the need for fetching enum property value in the .ts files arises `getEnumPropertyValue()` function is at your disposal, result of which, for example you can pass into the transloco service to get the actual translated value for passed in translation key. With this approach we are avoiding need for instantiating `EnumPropertyPipe` class and accessing the `transform` method. To avoid writing explicit casting in the code, you can pass in the key you are searching for which will infer type of the underlying data.
 
 ```ts
-import { getTranslationKey } from '@infinum/ngx-nuts-and-bolts';
+import { getEnumPropertyValue } from '@infinum/ngx-nuts-and-bolts';
 
 @Component({
 	selector: 'app-example',
@@ -84,8 +84,8 @@ export class ExampleComponent {
 	private readonly transloco = inject(TranslocoService);
 
 	private translationDemoMethod(): void {
-		const translationKey = getTranslationKey(Directions.NORTH, directionsData);
-		const translation = this.transloco.translate(translationKey as string);
+		const translationKey = getEnumPropertyValue(Directions.NORTH, directionsData);
+		const translation = this.transloco.translate(translationKey);
 	}
 }
 ```

--- a/libs/ngx-nuts-and-bolts/enum-property/src/enum-property.pipe.spec.ts
+++ b/libs/ngx-nuts-and-bolts/enum-property/src/enum-property.pipe.spec.ts
@@ -28,7 +28,7 @@ describe('EnumPropertyPipe', () => {
 			theAnswer: number;
 			translationKey: string;
 		},
-		number | string
+		'translationKey' | 'theAnswer'
 	>;
 
 	beforeEach(() => {

--- a/libs/ngx-nuts-and-bolts/enum-property/src/enum-property.pipe.ts
+++ b/libs/ngx-nuts-and-bolts/enum-property/src/enum-property.pipe.ts
@@ -4,34 +4,36 @@ import { Pipe, PipeTransform } from '@angular/core';
 	name: 'enumProperty',
 	standalone: true,
 })
-export class EnumPropertyPipe<TEnum extends string, TEnumDataObject extends Record<string, TReturnValue>, TReturnValue>
-	implements PipeTransform
+export class EnumPropertyPipe<
+	TEnum extends string,
+	TEnumDataObject extends Record<string, unknown>,
+	TKey extends keyof TEnumDataObject
+> implements PipeTransform
 {
 	public transform(
 		value: TEnum,
 		enumData: Record<TEnum, TEnumDataObject>,
-		key: keyof TEnumDataObject = 'translationKey',
+		key: TKey = 'translationKey' as TKey,
 		showWarning = true
-	): TReturnValue | TEnum | null {
-		return getTranslationKey(value, enumData, key, showWarning);
+	) {
+		try {
+			return getEnumPropertyValue(value, enumData, key);
+		} catch (e) {
+			if (showWarning) {
+				console.warn(e);
+			}
+			return null;
+		}
 	}
 }
 
-export function getTranslationKey<
+export function getEnumPropertyValue<
 	TEnum extends string,
-	TEnumDataObject extends Record<string, TReturnValue>,
-	TReturnValue
->(
-	value: TEnum,
-	enumData: Record<TEnum, TEnumDataObject>,
-	key: keyof TEnumDataObject = 'translationKey',
-	showWarning = true
-): TReturnValue | TEnum | null {
+	TEnumDataObject extends Record<string, unknown>,
+	TKey extends keyof TEnumDataObject
+>(value: TEnum, enumData: Record<TEnum, TEnumDataObject>, key: TKey = 'translationKey' as TKey) {
 	if (enumData[value]?.[key] === undefined) {
-		if (showWarning) {
-			console.warn(`No property for key "${String(key)}" for enum value "${value}" `, enumData);
-		}
-		return null;
+		throw new Error(`No property for key "${String(key)}" for enum value "${value}" `);
 	}
 
 	return enumData[value][key];

--- a/libs/ngx-nuts-and-bolts/enum-property/src/enum-property.pipe.ts
+++ b/libs/ngx-nuts-and-bolts/enum-property/src/enum-property.pipe.ts
@@ -13,12 +13,26 @@ export class EnumPropertyPipe<TEnum extends string, TEnumDataObject extends Reco
 		key: keyof TEnumDataObject = 'translationKey',
 		showWarning = true
 	): TReturnValue | TEnum | null {
-		if (enumData[value]?.[key] === undefined) {
-			if (showWarning) {
-				console.warn(`No property for key "${String(key)}" for enum value "${value}" `, enumData);
-			}
-			return null;
-		}
-		return enumData[value][key];
+		return getTranslationKey(value, enumData, key, showWarning);
 	}
+}
+
+export function getTranslationKey<
+	TEnum extends string,
+	TEnumDataObject extends Record<string, TReturnValue>,
+	TReturnValue
+>(
+	value: TEnum,
+	enumData: Record<TEnum, TEnumDataObject>,
+	key: keyof TEnumDataObject = 'translationKey',
+	showWarning = true
+): TReturnValue | TEnum | null {
+	if (enumData[value]?.[key] === undefined) {
+		if (showWarning) {
+			console.warn(`No property for key "${String(key)}" for enum value "${value}" `, enumData);
+		}
+		return null;
+	}
+
+	return enumData[value][key];
 }

--- a/ngx-nuts-and-bolts-docs/docs/enum-property.md
+++ b/ngx-nuts-and-bolts-docs/docs/enum-property.md
@@ -69,3 +69,21 @@ export class ExampleComponent {
 ```
 
 Here, since `directionsData` doesn't have `differentKey` property for any of the enum values, `undefined` would be returned.
+If the need for retrieving enum property value arises you can use `getEnumPropertyValue()` function directly in your .ts file without the need for instantiating new EnumPropertyPipe instance.
+
+```ts
+import { getEnumPropertyValue } from '@infinum/ngx-nuts-and-bolts';
+
+@Component({
+	selector: 'app-example',
+	template: ``,
+})
+export class ExampleComponent {
+	public enumValue = Directions.NORTH;
+	public directionsData = directionsData;
+
+	private demoMethod(): void {
+		const enumPropertyValue = getEnumPropertyValue(Directions.NORTH, directionsData);
+	}
+}
+```

--- a/ngx-nuts-and-bolts-docs/docs/enum-property.md
+++ b/ngx-nuts-and-bolts-docs/docs/enum-property.md
@@ -82,8 +82,11 @@ export class ExampleComponent {
 	public enumValue = Directions.NORTH;
 	public directionsData = directionsData;
 
-	private demoMethod(): void {
-		const enumPropertyValue = getEnumPropertyValue(Directions.NORTH, directionsData);
+	private readonly transloco = inject(TranslocoService);
+
+	private translationDemoMethod(): void {
+		const translationKey = getEnumPropertyValue(Directions.NORTH, directionsData);
+		const translation = this.transloco.translate(translationKey);
 	}
 }
 ```


### PR DESCRIPTION
# Description

This PR adds function for fetching enum property values. Logic from the enum property pipe is extracted to aforementioned function to be more flexible when need for fetching e.g. translation key in the .ts files. Types are also adjusted, so now the function infers the type of data you are trying to retrieve based on the key you pass in the function. 

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
