### PR TITLE
Fix and add missing imports in the docs

### DIFF
--- a/ngx-nuts-and-bolts-docs/docs/animations.md
+++ b/ngx-nuts-and-bolts-docs/docs/animations.md
@@ -16,6 +16,8 @@ This library includes two commonly used animations — `fadeAnimation()` and `he
 ## 2. Usage
 
 ```ts
+import { fadeAnimation, heightAnimation } from '@infinum/ngx-nuts-and-bolts/animations';
+
 @NgComponent({
 	animations: [heightAnimation(), fadeAnimation()],
 })

--- a/ngx-nuts-and-bolts-docs/docs/di-token-type.md
+++ b/ngx-nuts-and-bolts-docs/docs/di-token-type.md
@@ -7,6 +7,8 @@ sidebar_label: DI Token Type
 Use `DITokenType` in cases when you want to infer types of injection tokens in environments where typescript doesn't infer this automatically. E.g. when defining providers (most useful for useFactory providers)
 
 ```typescript
+import { DITokenType } from '@infinum/ngx-nuts-and-bolts/utility-types';
+
 type SomeType = {
 	name: string;
 	description: string;

--- a/ngx-nuts-and-bolts-docs/docs/enum-property.md
+++ b/ngx-nuts-and-bolts-docs/docs/enum-property.md
@@ -43,6 +43,8 @@ export const directionsData: Record<Directions, ITranslatableEnum> = {
 You can bring both of these into a component and use them together as such:
 
 ```ts
+import { EnumPropertyPipe } from '@infinum/ngx-nuts-and-bolts/enum-property';
+
 @Component({
 	selector: 'app-example',
 	template: ` {{ enumValue | enumProperty : directionsData }} `,
@@ -72,7 +74,7 @@ Here, since `directionsData` doesn't have `differentKey` property for any of the
 If the need for retrieving enum property value arises you can use `getEnumPropertyValue()` function directly in your .ts file without the need for instantiating new EnumPropertyPipe instance.
 
 ```ts
-import { getEnumPropertyValue } from '@infinum/ngx-nuts-and-bolts';
+import { getEnumPropertyValue } from '@infinum/ngx-nuts-and-bolts/enum-property';
 
 @Component({
 	selector: 'app-example',

--- a/ngx-nuts-and-bolts-docs/docs/form-utils/file-cva.md
+++ b/ngx-nuts-and-bolts-docs/docs/form-utils/file-cva.md
@@ -18,6 +18,8 @@ First, define your FormControl and expect the value to be `FileList | null`:
 
 <!-- prettier-ignore-start -->
 ```ts
+import { fileExtensionValidator, FileControlValueAccessorDirective } from '@infinum/ngx-nuts-and-bolts/form-utils';
+
 class MyComponent {
   protected readonly allowedExtensions = [
     '.jpg',

--- a/ngx-nuts-and-bolts-docs/docs/form-utils/form-value-type.md
+++ b/ngx-nuts-and-bolts-docs/docs/form-utils/form-value-type.md
@@ -24,6 +24,8 @@ export function createExampleForm() {
 Now, pass the function's return type using the TypeScript `ReturnType` utility type to the form type helper as a generic argument and create new form value and raw form value types as needed for this specific form.
 
 ```ts
+import { FormValue, RawFormValue } from '@infinum/ngx-nuts-and-bolts/form-utils';
+
 export type ExampleFormValue = FormValue<ReturnType<typeof createExampleForm>>;
 export type ExampleRawFormValue = RawFormValue<ReturnType<typeof createExampleForm>>;
 ```

--- a/ngx-nuts-and-bolts-docs/docs/in-view.md
+++ b/ngx-nuts-and-bolts-docs/docs/in-view.md
@@ -17,6 +17,8 @@ Often times, one may be interested to know whether or not piece a of DOM is visi
 Simply add `infInView` directive to whatever DOM node you care about. You can then handle notifications from `(inView)` EventEmitter.
 
 ```ts
+import { InViewDirective } from '@infinum/ngx-nuts-and-bolts/in-view';
+
 @Component({
 	selector: 'app-example',
 	template: `<div (infInView)="inView$.next($event)>{{ inView$ | async }}</div>`,
@@ -29,6 +31,8 @@ class ExampleComponent {
 You can also select the directive with a `@ViewChild` as you would any other and read `isInView` property which reflects current status.
 
 ```ts
+import { InViewDirective } from '@infinum/ngx-nuts-and-bolts/in-view';
+
 @Component({
 	selector: 'app-example',
 	template: `<div infInView>{{ inViewDirectiveRef.isInView }}</div>`,
@@ -42,6 +46,8 @@ class ExampleComponent {
 Additionally, you can also export the directive instance in a template directly.
 
 ```ts
+import { InViewDirective } from '@infinum/ngx-nuts-and-bolts/in-view';
+
 @Component({
 	selector: 'app-example',
 	template: `<div infInView #infInViewRef="infInView">{{ infInViewRef.isInView }}</div>`,

--- a/ngx-nuts-and-bolts-docs/docs/loading-state.md
+++ b/ngx-nuts-and-bolts-docs/docs/loading-state.md
@@ -27,6 +27,8 @@ By default, loader enter delay is set to 250ms and loader leave delay is set to 
 Provide the desired values in a provider in your `AppModule`:
 
 ```ts
+import { LoadingState } from '@infinum/ngx-nuts-and-bolts/loading-state';
+
 {
 	provide: LOADING_STATE_CONFIG,
 	useValue: {
@@ -41,6 +43,8 @@ Provide the desired values in a provider in your `AppModule`:
 Pass the desired values via component-specific provider (this will override any values set in the global provider):
 
 ```ts
+import { LoadingState } from '@infinum/ngx-nuts-and-bolts/loading-state';
+
 @Component({
 	...
 	providers: [{
@@ -77,6 +81,7 @@ There are two ways to implement handling the loading and error states:
 ```
 
 ```ts
+import { LoadingState } from '@infinum/ngx-nuts-and-bolts/loading-state';
 
 interface ITemplateData { ... }
 

--- a/ngx-nuts-and-bolts-docs/docs/table-state.md
+++ b/ngx-nuts-and-bolts-docs/docs/table-state.md
@@ -20,6 +20,13 @@ Helper functions can be used individually or, as the example below shows, with o
 ```ts
 
 import {isEqual} from 'loadsh';
+import {
+	createCustomFiltersObservable,
+	createPaginationObservable,
+	createSortObservable,
+	IPageInfo,
+	ISortInfo,
+} from '@infinum/ngx-nuts-and-bolts/table-state';
 
 interface ITemplateData{
 	data: Data;
@@ -77,6 +84,8 @@ export class MyComponent extends LoadingStateComponent {
 Setting of the query parameters is even simpler as shown in code snippets below. With little mapping, interfaces for pagination and sorting should be usable with most of the 3rd party out-of-the-box data table events. While `changeFilters()` function accepts generic object as filter value.
 
 ```ts
+import { changePage } from '@infinum/ngx-nuts-and-bolts/table-state';
+
 ...
 public onPageChange(event: PageEvent): void{
 	const pageInfo: IPageInfo{
@@ -89,6 +98,8 @@ public onPageChange(event: PageEvent): void{
 ```
 
 ```ts
+import { changeSort } from '@infinum/ngx-nuts-and-bolts/table-state';
+
 ...
 public onSortChange(event: SortEvent): void{
 	const sortInfo: ISortInfo{
@@ -101,6 +112,8 @@ public onSortChange(event: SortEvent): void{
 ```
 
 ```ts
+import { changeFilters } from '@infinum/ngx-nuts-and-bolts/table-state';
+
 ...
 public onFiltersChange(event: FilterEvent): void{
 	changeFilters(this.router, event)

--- a/ngx-nuts-and-bolts-docs/docs/testing-utils/async-data.md
+++ b/ngx-nuts-and-bolts-docs/docs/testing-utils/async-data.md
@@ -21,6 +21,8 @@ This specific implementation uses `observeOn` operator with `asyncScheduler`, cr
 When returning the mock data in test doubles, simply wrap the data using `asyncData` function and the data will be returned asynchronously.
 
 ```ts
+import { asyncData } from '@infinum/ngx-nuts-and-bolts/testing-utils';
+
 public getTestingData(data: TData): Observable<TData>{
 	return asyncData(data);
 }

--- a/ngx-nuts-and-bolts-docs/docs/testing-utils/async-error.md
+++ b/ngx-nuts-and-bolts-docs/docs/testing-utils/async-error.md
@@ -39,6 +39,8 @@ When returning the mocked error in test suites or test doubles, simply wrap the 
 ### 1.1. Test double scenario
 
 ```ts
+import { asyncData, asyncError } from '@infinum/ngx-nuts-and-bolts/testing-utils';
+
 export class MockedDataFetchingService {
 	public getSomeData(data: TData): Observable<TData> {
 		return data
@@ -51,6 +53,8 @@ export class MockedDataFetchingService {
 ### 1.2. Test suite scenario
 
 ```ts
+import { asyncError } from '@infinum/ngx-nuts-and-bolts/testing-utils';
+
 describe('asyncError demo', () => {
 	...
 	it('should return not found error if data does not exist', () => {

--- a/ngx-nuts-and-bolts-docs/docs/testing-utils/extract-public.md
+++ b/ngx-nuts-and-bolts-docs/docs/testing-utils/extract-public.md
@@ -16,6 +16,8 @@ Good question! Perhaps unexpectedly, that would require you to implement private
 ## 1. Usage
 
 ```ts
+import { ExtractPublic } from '@infinum/ngx-nuts-and-bolts/testing-utils';
+
 export class UserTestingService implements ExtractPublic<UserService>{
 ...
 }

--- a/ngx-nuts-and-bolts-docs/docs/testing-utils/mock-storage.md
+++ b/ngx-nuts-and-bolts-docs/docs/testing-utils/mock-storage.md
@@ -9,6 +9,8 @@ When you need to interact with storage but still you are testing only a unit of 
 ## 1. Usage
 
 ```ts
+import { MockStorage } from '@infinum/ngx-nuts-and-bolts/testing-utils';
+
 let storage: Storage;
 
 beforeEach(async () => {


### PR DESCRIPTION
# Description
This PR adds relevant file imports where missing and updates the existing outdated ones. Often when importing something from the lib for the first time I have to do a manual import, but the imports weren't listed in the docs so it was a bit troublesome to find the correct import.

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
